### PR TITLE
Add patch support for 5.8 kernel and add P812 controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Tested on following hardware so far:
 
 * HP Smart Array P410i (PCI ID: 103c:3245, board ID: 0x3245103c,
 firmware: 6.64)
+* HP Smart Array P812 (PCI ID: 103c:3249, board ID: 0x3249103c,
+firmware: 6.64)
 * Hewlett-Packard Company Smart Array G6 controllers / P410 (PCI ID:
 103c:323a, board ID: 0x3243103c, firmware: 6.64)
 * Hewlett-Packard Company Smart Array G6 controllers / P212 (PCI ID:

--- a/contrib/dkms/patch.sh
+++ b/contrib/dkms/patch.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-VERSION=${1:-5.4}
+VERSION=${1:-5.8}
 
 echo "Patching for kernel ${VERSION}"
 


### PR DESCRIPTION
Added P812 controller to the supported list of controllers.
This was tested on truenas scale with kernel 5.8.0-1

Compilation of the dkms driver first failed but after changing the patch.sh file it worked.
![image](https://user-images.githubusercontent.com/12977799/100855667-ba42c000-348a-11eb-872f-a5c5e2e5d762.png)
